### PR TITLE
Add PSQL Support

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,0 +1,184 @@
+# Certificate Management API for OCSP Server
+
+This API allows you to add, revoke, and query certificates in the database used by the OCSP server.
+
+## Configuration
+
+To enable the API, add the following parameters to your `config.toml` file:
+
+```toml
+# API Configuration
+enable_api = true # Enable the API
+api_keys = ["your-secure-api-key"] # List of valid API keys
+```
+
+## Generating Secure API Keys
+
+API keys should be random, hard to guess, and unique. Here are different methods to generate secure API keys:
+
+### Using OpenSSL
+
+The simplest way to generate a secure API key is using OpenSSL:
+
+```bash
+# Generate a 32-byte random hexadecimal string
+openssl rand -hex 32
+```
+
+Example output: `a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6`
+
+After generating an API key, add it to the `api_keys` array in your `config.toml` file.
+
+## Authentication
+
+All API requests must include an `X-API-Key` header with a valid API key.
+
+## Finding Certificate Numbers
+
+To use this API, you need the certificate number in the correct format (with `0x` prefix and lowercase hexadecimal digits). You can extract a certificate's serial number and format it properly using this command:
+
+```bash
+openssl x509 -in your_certificate.pem -serial -noout | awk -F= '{print "0x" tolower($2)}'
+```
+
+This will output the certificate number in the exact format required by the API endpoints (e.g., `0x3b6ea97e1bf7699397e2109846e4f356be982542`).
+
+## Endpoints
+
+### Health Check
+```
+GET /api/health
+```
+Returns "OK" if the service is available.
+
+### Add a Certificate
+```
+POST /api/certificates
+```
+
+**Request Body:**
+```json
+{
+  "cert_num": "0x123456789ABCDEF"
+}
+```
+
+**Example Response:**
+```json
+{
+  "cert_num": "0x123456789ABCDEF",
+  "status": "Valid",
+  "message": "Certificate added successfully"
+}
+```
+
+### Revoke a Certificate
+```
+POST /api/certificates/revoke
+```
+
+**Request Body:**
+```json
+{
+  "cert_num": "0x123456789ABCDEF",
+  "reason": "key_compromise",
+  "revocation_time": "2025-03-18T12:00:00" // Optional, uses the current time if not provided
+}
+```
+
+Valid revocation reasons are:
+- `unspecified`
+- `key_compromise`
+- `ca_compromise`
+- `affiliation_changed`
+- `superseded`
+- `cessation_of_operation`
+- `certificate_hold`
+- `privilege_withdrawn`
+- `aa_compromise`
+
+**Example Response:**
+```json
+{
+  "cert_num": "0x123456789ABCDEF",
+  "status": "Revoked",
+  "message": "Certificate revoked successfully"
+}
+```
+
+### Get a Certificate's Status
+```
+GET /api/certificates/{cert_num}
+```
+
+**Example Response:**
+```json
+{
+  "cert_num": "0x123456789ABCDEF",
+  "status": "Valid",
+  "message": "Certificate status retrieved: Valid"
+}
+```
+
+### List All Certificates
+```
+GET /api/certificates
+```
+
+Optional parameters:
+- `status`: Filter by status (`Valid`, `Revoked`, or `all`)
+  - If no `status` parameter is provided or `status=all` is used, all certificates will be returned
+  - Use `status=Valid` to return only valid certificates
+  - Use `status=Revoked` to return only revoked certificates
+
+**Example Response:**
+```json
+[
+  {
+    "cert_num": "0x123456789ABCDEF",
+    "status": "Valid",
+    "message": ""
+  },
+  {
+    "cert_num": "0x987654321FEDCBA",
+    "status": "Revoked",
+    "message": ""
+  }
+]
+```
+
+## Usage Examples with cURL
+
+### Add a Certificate
+```bash
+curl -X POST http://localhost:9000/api/certificates \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: your-api-key" \
+  -d '{"cert_num": "0x123456789ABCDEF"}'
+```
+
+### Revoke a Certificate
+```bash
+curl -X POST http://localhost:9000/api/certificates/revoke \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: your-api-key" \
+  -d '{"cert_num": "0x123456789ABCDEF", "reason": "key_compromise"}'
+```
+
+### Get a Certificate's Status
+```bash
+curl -X GET http://localhost:9000/api/certificates/0x123456789ABCDEF \
+  -H "X-API-Key: your-api-key"
+```
+
+### List All Valid Certificates
+```bash
+curl -X GET "http://localhost:9000/api/certificates?status=Valid" \
+  -H "X-API-Key: your-api-key"
+```
+
+### List All Certificates (Explicitly)
+```bash
+curl -X GET "http://localhost:9000/api/certificates?status=all" \
+  -H "X-API-Key: your-api-key"
+```

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ exclude = [
 
 [dependencies]
 clap = { version = "4.5.32", features = ["derive", "cargo"] }
-chrono = { version = "~0.4.40", default-features = false, features = ["std"]}
+chrono = { version = "~0.4.40", default-features = false, features = ["std", "serde"] }
 config-file = "~0.2.3"
 serde = "~1.0.219"
 diesel = { version = "2.2.8", features = ["mysql", "postgres", "r2d2", "chrono"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ clap = { version = "4.5.32", features = ["derive", "cargo"] }
 chrono = { version = "~0.4.40", default-features = false, features = ["std", "serde"] }
 config-file = "~0.2.3"
 serde = "~1.0.219"
-diesel = { version = "2.2.8", features = ["mysql", "postgres", "r2d2", "chrono"] }
+diesel = { version = "2.2.8", features = ["mysql", "postgres", "sqlite", "r2d2", "chrono"] }
 r2d2 = "0.8.10"
 ocsp = {git = "https://github.com/DorianCoding/ocsp-rs.git", tag="1.0.0" }
 pem = "3.0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,10 +2,10 @@
 name = "ocsp-server"
 authors = ["DorianCoding <108593662+DorianCoding@users.noreply.github.com>"]
 description = "OCSP server, listening for requests to give responses."
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
-license = "GPL-3.0-only"
 rust-version = "1.85"
+license = "GPL-3.0-only"
 repository = "https://github.com/DorianCoding/OCSP_server"
 keywords = ["ocsp", "server", "ocsp-response"]
 categories = ["caching", "cryptography"]
@@ -19,20 +19,32 @@ exclude = [
 clap = { version = "4.5.32", features = ["derive", "cargo"] }
 chrono = { version = "~0.4.40", default-features = false, features = ["std"]}
 config-file = "~0.2.3"
-hex = "~0.4.3"
-mysql = { version = "~26.0.0", default-features = false, features = ["minimal"]}
-ocsp = {git = "https://github.com/DorianCoding/ocsp-rs.git", tag="1.0.0" }
-#ocsp = {git = "https://github.com/maicallist/ocsp-rs.git" }
-pem = "3.0.5"
-#openssl-sys = { version = "~0.9.103", features = ["vendored" ]}
-ring = "0.17.14"
-rocket = "~0.5.1"
 serde = "~1.0.219"
+diesel = { version = "2.2.8", features = ["mysql", "postgres", "r2d2", "chrono"] }
+r2d2 = "0.8.10"
+ocsp = {git = "https://github.com/DorianCoding/ocsp-rs.git", tag="1.0.0" }
+pem = "3.0.5"
+openssl = { version = "0.10.71", features = ["vendored"] }
+ring = "0.17.14"
 x509-parser = "~0.17.0"
+hex = "~0.4.3"
 zeroize = { version = "~1.8.1", features = ["std", "zeroize_derive"] }
+log = "0.4.20"
+async-trait = "0.1.79"
+tokio = { version = "1.36.0", features = ["rt-multi-thread", "macros", "fs", "io-util", "time"] }
+
+[dependencies.rocket]
+version = "0.5.1"
+features = ["json"]
+
+[dev-dependencies]
+mockall = "0.12.1"
 
 [profile.release]
 strip = "symbols"
+lto = true
+codegen-units = 1
+opt-level = 3
 
 [lints.rust]
 unsafe_code = "deny"

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ dbport = 3306 # Optional: Default 3306 for MySQL, 5432 for PostgreSQL
 dbname = "certs" #Name to connect to MySql data
 dbpassword = "certdata" #Password to connect to cert data
 port = 9000 #Port to listen to, from 1 to 65535. Cannot use a port already used by another service (privileged ports allowed if used as root or as a service). By default 9000
+listen_ip = "0.0.0.0" # Optional: IP address to listen on (default: 127.0.0.1)
 timeout = 5 #Optional timeout, default 5s
 cachefolder = "cache/" #Folder to cache data (relative or absolute, will be created if not present)
 itcert = "/var/public_files/it_cert.crt" #Path to intermediate certificate as PEM format

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The config file should contain the following informations :
 #Config file, all fields are compulsory
 cachedays = 3 #Number of days a response is valid once created (only for valid certificates)
 dbip = "127.0.0.1" #Optional. IP to connect to MySql database. If absent, use of unix socket.
-db_type = "mysql" # Can be "mysql" or "postgres"
+db_type = "mysql" # Can be "mysql" or "postgres" or "sqlite"
 dbuser = "cert" #Username to connect to MySql database
 dbport = 3306 # Optional: Default 3306 for MySQL, 5432 for PostgreSQL
 dbname = "certs" #Name to connect to MySql data

--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ itkey = "/var/private_files/it_privkey.pem" #Path to intermediate private key, k
 revocextended = true #Optional, if you want to enable EXTENDED_REVOCATION
 caching = true #Optional, enable caching or enable nonce response.
 create_table = true # Optional: Creates the table if it doesn't exist
+table_name = "custom_certs" # Optional: Custom table name (default is list_certs for MySQL, ocsp_list_certs for PostgreSQL)
+enable_api = true # Optional: Enable the certificate management API
+api_keys = ["secure-api-key-1", "secure-api-key-2"] # Optional: List of valid API keys for authentication
 ```
 
 > [!CAUTION]
@@ -67,7 +70,7 @@ Create your config file in the main directory and call `service.sh` as root. The
 ## MySql table
 This script requires a table with this kind of structure :
 ```
-CREATE TABLE `ocsp_list_certs` (
+CREATE TABLE `list_certs` (
   `cert_num` varchar(50) NOT NULL,
   `revocation_time` datetime DEFAULT NULL,
   `revocation_reason` enum('unspecified','key_compromise','ca_compromise','affiliation_changed','superseded','cessation_of_operation','certificate_hold','privilege_withdrawn','aa_compromise') DEFAULT NULL,

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ----
 
-This software implements a OCSP responder in Rust, fetching certificate status in a Mysql/MariaDB database. Unlike the Python implementation, it **does implement its own TCP listener** on a user-selected port. 
+This software implements a OCSP responder in Rust, fetching certificate status in a Mysql/MariaDB database. Unlike the Python implementation, it **does implement its own TCP listener** on a user-selected port.
 *It will answer to any **GET or POST** requests on any URL*.
 ## Requirements
 - A CA certificate (self-signed allowed) and/or an intermediate CA that will sign leaf certificates.
@@ -30,16 +30,19 @@ The config file should contain the following informations :
 #Config file, all fields are compulsory
 cachedays = 3 #Number of days a response is valid once created (only for valid certificates)
 dbip = "127.0.0.1" #Optional. IP to connect to MySql database. If absent, use of unix socket.
-timeout = 5 #Optional timeout, default 5s
+db_type = "mysql" # Can be "mysql" or "postgres"
 dbuser = "cert" #Username to connect to MySql database
-port = 9000 #Port to listen to, from 1 to 65535. Cannot use a port already used by another service (privileged ports allowed if used as root or as a service). By default 9000
+dbport = 3306 # Optional: Default 3306 for MySQL, 5432 for PostgreSQL
 dbname = "certs" #Name to connect to MySql data
 dbpassword = "certdata" #Password to connect to cert data
+port = 9000 #Port to listen to, from 1 to 65535. Cannot use a port already used by another service (privileged ports allowed if used as root or as a service). By default 9000
+timeout = 5 #Optional timeout, default 5s
 cachefolder = "cache/" #Folder to cache data (relative or absolute, will be created if not present)
 itcert = "/var/public_files/it_cert.crt" #Path to intermediate certificate as PEM format
+itkey = "/var/private_files/it_privkey.pem" #Path to intermediate private key, keep it secret (PKCS#8 format, only RSA keys supported so far)
 revocextended = true #Optional, if you want to enable EXTENDED_REVOCATION
 caching = true #Optional, enable caching or enable nonce response.
-itkey = "/var/private_files/it_privkey.pem" #Path to intermediate private key, keep it secret (PKCS#8 format, only RSA keys supported so far)
+create_table = true # Optional: Creates the table if it doesn't exist
 ```
 
 > [!CAUTION]
@@ -64,7 +67,7 @@ Create your config file in the main directory and call `service.sh` as root. The
 ## MySql table
 This script requires a table with this kind of structure :
 ```
-CREATE TABLE `list_certs` (
+CREATE TABLE `ocsp_list_certs` (
   `cert_num` varchar(50) NOT NULL,
   `revocation_time` datetime DEFAULT NULL,
   `revocation_reason` enum('unspecified','key_compromise','ca_compromise','affiliation_changed','superseded','cessation_of_operation','certificate_hold','privilege_withdrawn','aa_compromise') DEFAULT NULL,
@@ -168,15 +171,15 @@ OCSP Response Data:
 
 > OCSP Server - OCSP responder in Rust
 > Copyright (C) 2023 DorianCoding
-> 
+>
 > This program is free software: you can redistribute it and/or modify
 > it under the terms of the GNU General Public License as published by
 > the Free Software Foundation, under version 3 of the License only.
-> 
+>
 > This program is distributed in the hope that it will be useful,
 > but WITHOUT ANY WARRANTY; without even the implied warranty of
 > MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 > GNU General Public License for more details.
-> 
+>
 > You should have received a copy of the GNU General Public License
 > along with this program.  If not, see <https://www.gnu.org/licenses/>.

--- a/config.toml
+++ b/config.toml
@@ -1,11 +1,17 @@
 #Config file, all fields are compulsory
 cachedays = 3
+db_type = "mysql" # Can be "mysql" or "postgres"
 dbip = "127.0.0.1"
+dbport = 3306 # Optional: Default 3306 for MySQL, 5432 for PostgreSQL
 port = 9000
 timeout = 10
-dbuser = "cert"
-dbpassword = "cert"
+dbuser = "ocsp"
+dbpassword = "ocsp"
 dbname = "certs"
 cachefolder = "cache/"
 itcert = "test_files/cert.pem"
-itkey = "test_files/keyp8.pk8"
+itkey = "test_files/key.pem" # Supports PKCS#8, PEM PKCS#1 (RSA) formats
+revocextended = false # Optional, if you want to enable EXTENDED_REVOCATION
+caching = false # Optional, enable caching or enable nonce response.
+create_table = true # Optional: Creates the table if it doesn't exist
+table_name = "custom_certs" # Optional: Custom table name (default is list_certs for MySQL, ocsp_list_certs for PostgreSQL)

--- a/config.toml
+++ b/config.toml
@@ -15,3 +15,5 @@ revocextended = false # Optional, if you want to enable EXTENDED_REVOCATION
 caching = false # Optional, enable caching or enable nonce response.
 create_table = true # Optional: Creates the table if it doesn't exist
 table_name = "custom_certs" # Optional: Custom table name (default is list_certs for MySQL, ocsp_list_certs for PostgreSQL)
+enable_api = true # Optional: Enable the certificate management API
+api_keys = ["secure-api-key-1", "secure-api-key-2"] # Optional: List of valid API keys for authentication

--- a/config.toml
+++ b/config.toml
@@ -4,6 +4,7 @@ db_type = "mysql" # Can be "mysql" or "postgres" or "sqlite"
 dbip = "127.0.0.1"
 dbport = 3306 # Optional: Default 3306 for MySQL, 5432 for PostgreSQL
 port = 9000
+listen_ip = "0.0.0.0" # Optional: IP address to listen on (default: 127.0.0.1)
 timeout = 10
 dbuser = "ocsp"
 dbpassword = "ocsp"

--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,6 @@
 #Config file, all fields are compulsory
 cachedays = 3
-db_type = "mysql" # Can be "mysql" or "postgres"
+db_type = "mysql" # Can be "mysql" or "postgres" or "sqlite"
 dbip = "127.0.0.1"
 dbport = 3306 # Optional: Default 3306 for MySQL, 5432 for PostgreSQL
 port = 9000

--- a/shell.nix
+++ b/shell.nix
@@ -10,6 +10,7 @@ pkgs.mkShell {
     git
     openssl
     libmysqlclient
+    sqlite
     postgresql
     pkg-config
   ];

--- a/shell.nix
+++ b/shell.nix
@@ -5,6 +5,7 @@ pkgs.mkShell {
     rustc
     cargo
     cargo-audit
+    clippy
     rustfmt
     rust-analyzer
     git

--- a/shell.nix
+++ b/shell.nix
@@ -7,6 +7,11 @@ pkgs.mkShell {
     cargo-audit
     rustfmt
     rust-analyzer
+    git
+    openssl
+    libmysqlclient
+    postgresql
+    pkg-config
   ];
 
   shellHook = ''

--- a/shell.nix
+++ b/shell.nix
@@ -10,7 +10,7 @@ pkgs.mkShell {
   ];
 
   shellHook = ''
-    rustfmt --edition 2024 src/main.rs
+    rustfmt --edition 2024 src/*.rs
     cargo audit
   '';
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,0 +1,203 @@
+use crate::database::Database;
+use crate::r#struct::{ApiKey, CertificateRequest, CertificateResponse, RevocationRequest};
+use chrono::Utc;
+use log::{error, info, warn};
+use rocket::http::Status;
+use rocket::request::{FromRequest, Outcome, Request};
+use rocket::serde::json::Json;
+use rocket::{get, post, routes, State};
+use std::sync::Arc;
+
+pub fn api_routes() -> Vec<rocket::Route> {
+    routes![
+        health_check,
+        add_certificate,
+        revoke_certificate,
+        get_certificate_status,
+        list_certificates
+    ]
+}
+
+/// API key authentication guard for secure endpoints
+#[rocket::async_trait]
+impl<'r> FromRequest<'r> for ApiKey {
+    type Error = ();
+
+    async fn from_request(request: &'r Request<'_>) -> Outcome<Self, Self::Error> {
+        // Get API key from header
+        let api_key = request.headers().get_one("X-API-Key");
+
+        match api_key {
+            Some(key) => {
+                let config = request.rocket().state::<Arc<crate::r#struct::Config>>();
+
+                match config {
+                    Some(config) => {
+                        if let Some(valid_keys) = &config.api_keys {
+                            if valid_keys.contains(&key.to_string()) {
+                                Outcome::Success(ApiKey(key.to_string()))
+                            } else {
+                                warn!("Invalid API key attempted: {}", key);
+                                Outcome::Error((Status::Unauthorized, ()))
+                            }
+                        } else {
+                            // If no API keys are configured, reject all requests
+                            warn!("API keys not configured but API endpoint accessed");
+                            Outcome::Error((Status::Unauthorized, ()))
+                        }
+                    }
+                    None => Outcome::Error((Status::InternalServerError, ())),
+                }
+            }
+            None => Outcome::Error((Status::Unauthorized, ())),
+        }
+    }
+}
+
+#[get("/health")]
+fn health_check() -> &'static str {
+    "OK"
+}
+
+/// Add a new certificate to the database
+#[post("/certificates", data = "<cert_request>")]
+async fn add_certificate(
+    _api_key: ApiKey,
+    cert_request: Json<CertificateRequest>,
+    db: &State<Box<dyn Database>>,
+) -> Result<Json<CertificateResponse>, Status> {
+    let cert = cert_request.into_inner();
+
+    // Validate certificate number format (should start with 0x)
+    if !cert.cert_num.starts_with("0x") {
+        return Err(Status::BadRequest);
+    }
+
+    match db.add_certificate(&cert.cert_num).await {
+        Ok(_) => {
+            info!("Certificate added successfully: {}", cert.cert_num);
+            Ok(Json(CertificateResponse {
+                cert_num: cert.cert_num,
+                status: "Valid".to_string(),
+                message: "Certificate added successfully".to_string(),
+            }))
+        }
+        Err(e) => {
+            error!("Failed to add certificate: {}", e);
+            Err(Status::InternalServerError)
+        }
+    }
+}
+
+/// Revoke a certificate
+#[post("/certificates/revoke", data = "<revoke_request>")]
+async fn revoke_certificate(
+    _api_key: ApiKey,
+    revoke_request: Json<RevocationRequest>,
+    db: &State<Box<dyn Database>>,
+) -> Result<Json<CertificateResponse>, Status> {
+    let request = revoke_request.into_inner();
+
+    // Validate certificate number format
+    if !request.cert_num.starts_with("0x") {
+        return Err(Status::BadRequest);
+    }
+
+    // Validate revocation reason
+    let valid_reasons = [
+        "unspecified",
+        "key_compromise",
+        "ca_compromise",
+        "affiliation_changed",
+        "superseded",
+        "cessation_of_operation",
+        "certificate_hold",
+        "privilege_withdrawn",
+        "aa_compromise",
+    ];
+
+    if !valid_reasons.contains(&request.reason.as_str()) {
+        return Err(Status::BadRequest);
+    }
+
+    // Use current time if not provided
+    let revocation_time = request
+        .revocation_time
+        .unwrap_or_else(|| Utc::now().naive_utc());
+
+    match db
+        .revoke_certificate(&request.cert_num, revocation_time, &request.reason)
+        .await
+    {
+        Ok(_) => {
+            info!("Certificate revoked successfully: {}", request.cert_num);
+            Ok(Json(CertificateResponse {
+                cert_num: request.cert_num,
+                status: "Revoked".to_string(),
+                message: "Certificate revoked successfully".to_string(),
+            }))
+        }
+        Err(e) => {
+            error!("Failed to revoke certificate: {}", e);
+            Err(Status::InternalServerError)
+        }
+    }
+}
+
+/// Get the status of a specific certificate
+#[get("/certificates/<cert_num>")]
+async fn get_certificate_status(
+    _api_key: ApiKey,
+    cert_num: String,
+    db: &State<Box<dyn Database>>,
+) -> Result<Json<CertificateResponse>, Status> {
+    let cert_num = if !cert_num.starts_with("0x") {
+        format!("0x{}", cert_num)
+    } else {
+        cert_num
+    };
+
+    match db.get_certificate_status(&cert_num).await {
+        Ok(cert_info) => Ok(Json(CertificateResponse {
+            cert_num: cert_num.clone(),
+            status: cert_info.status.clone(),
+            message: format!("Certificate status retrieved: {}", cert_info.status),
+        })),
+        Err(_) => Err(Status::NotFound),
+    }
+}
+
+/// List all certificates or filter by status
+#[get("/certificates?<status>")]
+async fn list_certificates(
+    _api_key: ApiKey,
+    status: Option<String>,
+    db: &State<Box<dyn Database>>,
+) -> Result<Json<Vec<CertificateResponse>>, Status> {
+    if let Some(ref s) = status {
+        if s != "Valid" && s != "Revoked" && s != "all" {
+            return Err(Status::BadRequest);
+        }
+    }
+
+    let filtered_status = status.filter(|s| s != "all");
+
+    match db.list_certificates(filtered_status).await {
+        Ok(certs) => {
+            let response = certs
+                .into_iter()
+                .map(|cert| CertificateResponse {
+                    cert_num: cert.cert_num,
+                    status: cert.status,
+                    message: String::new(),
+                })
+                .collect();
+
+            Ok(Json(response))
+        }
+        Err(e) => {
+            error!("Failed to list certificates: {}", e);
+            Err(Status::InternalServerError)
+        }
+    }
+}

--- a/src/database.rs
+++ b/src/database.rs
@@ -1,0 +1,516 @@
+use crate::r#struct::{
+    BoolResult, CertRecord, Config, DEFAULT_MYSQL_PORT, DEFAULT_MYSQL_TABLE, DEFAULT_POSTGRES_PORT,
+    DEFAULT_POSTGRES_TABLE,
+};
+use async_trait::async_trait;
+use chrono::{Datelike, Timelike};
+use diesel::prelude::*;
+use diesel::r2d2::{ConnectionManager, Pool};
+use diesel::sql_types;
+use diesel::{MysqlConnection, PgConnection};
+use log::{debug, info, warn};
+use ocsp::common::asn1::GeneralizedTime;
+use ocsp::response::{CertStatus as OcspCertStatus, CertStatusCode, CrlReason, RevokedInfo};
+use std::error::Error;
+use std::sync::Arc;
+use std::time::Duration;
+
+type MysqlPool = Pool<ConnectionManager<MysqlConnection>>;
+type PgPool = Pool<ConnectionManager<PgConnection>>;
+
+pub enum DatabaseType {
+    MySQL,
+    PostgreSQL,
+}
+
+impl DatabaseType {
+    pub fn from_string(s: &str) -> Self {
+        match s.to_lowercase().as_str() {
+            "postgres" | "postgresql" => DatabaseType::PostgreSQL,
+            _ => DatabaseType::MySQL,
+        }
+    }
+
+    #[allow(dead_code)]
+    fn default_table_name(&self) -> &'static str {
+        match self {
+            DatabaseType::MySQL => DEFAULT_MYSQL_TABLE,
+            DatabaseType::PostgreSQL => DEFAULT_POSTGRES_TABLE,
+        }
+    }
+}
+
+#[async_trait]
+pub trait Database: Send + Sync {
+    async fn check_cert(
+        &self,
+        certnum: &str,
+        revoked: bool,
+    ) -> Result<OcspCertStatus, Box<dyn Error + Send + Sync>>;
+
+    fn create_tables_if_needed(&self) -> Result<(), Box<dyn Error + Send + Sync>>;
+}
+
+pub struct DieselMysqlDatabase {
+    config: Arc<Config>,
+    pool: MysqlPool,
+    table_name: String,
+}
+
+impl DieselMysqlDatabase {
+    pub fn new(config: Arc<Config>) -> Result<Self, Box<dyn Error + Send + Sync>> {
+        let database_url = match &config.dbip {
+            Some(host) => format!(
+                "mysql://{}:{}@{}:{}/{}",
+                config.dbuser,
+                config.dbpassword,
+                host,
+                config.dbport.unwrap_or(DEFAULT_MYSQL_PORT),
+                config.dbname
+            ),
+            None => format!(
+                "mysql://{}:{}@localhost/{}",
+                config.dbuser, config.dbpassword, config.dbname
+            ),
+        };
+
+        let manager = ConnectionManager::<MysqlConnection>::new(database_url);
+        let pool = Pool::builder()
+            .max_size(15)
+            .connection_timeout(Duration::from_secs(config.time as u64))
+            .build(manager)?;
+
+        let table_name = config
+            .table_name
+            .clone()
+            .unwrap_or_else(|| DEFAULT_MYSQL_TABLE.to_string());
+
+        Ok(Self {
+            config,
+            pool,
+            table_name,
+        })
+    }
+
+    fn get_connection(
+        &self,
+    ) -> Result<
+        diesel::r2d2::PooledConnection<ConnectionManager<MysqlConnection>>,
+        Box<dyn Error + Send + Sync>,
+    > {
+        Ok(self.pool.get()?)
+    }
+}
+
+#[async_trait]
+impl Database for DieselMysqlDatabase {
+    async fn check_cert(
+        &self,
+        certnum: &str,
+        revoked: bool,
+    ) -> Result<OcspCertStatus, Box<dyn Error + Send + Sync>> {
+        let table_name = self.table_name.clone();
+        let cert_num = certnum.to_string();
+        let connection_manager = self.pool.clone();
+
+        let result = tokio::task::spawn_blocking(move || -> Result<OcspCertStatus, Box<dyn Error + Send + Sync>> {
+            let mut conn = connection_manager.get()?;
+
+            // Using text SQL query with explicit column names and types
+            let query = format!(
+                "SELECT cert_num, revocation_time, revocation_reason, status FROM {} WHERE cert_num = ?",
+                table_name
+            );
+
+            let results = diesel::sql_query(query)
+                .bind::<sql_types::Text, _>(&cert_num)
+                .load::<CertRecord>(&mut conn)?;
+
+            if results.is_empty() {
+                warn!("Entry not found for cert {}", cert_num);
+                if !revoked {
+                    Ok(OcspCertStatus::new(CertStatusCode::Unknown, None))
+                } else {
+                    Ok(OcspCertStatus::new(
+                        CertStatusCode::Revoked,
+                        Some(RevokedInfo::new(
+                            GeneralizedTime::new(1970, 1, 1, 0, 0, 0).unwrap(),
+                            Some(CrlReason::OcspRevokeCertHold),
+                        )),
+                    ))
+                }
+            } else {
+                let record = &results[0];
+                debug!("Entry found for cert {}, status {}", cert_num, record.status);
+
+                if record.status == "Revoked" {
+                    let time = GeneralizedTime::now();
+
+                    let time = if let Some(rt) = record.revocation_time {
+                        GeneralizedTime::new(
+                            rt.year(),
+                            rt.month(),
+                            rt.day(),
+                            rt.hour(),
+                            rt.minute(),
+                            rt.second(),
+                        ).unwrap_or(time)
+                    } else {
+                        time
+                    };
+
+                    let motif = record.revocation_reason.clone().unwrap_or_default();
+                    let motif: CrlReason = match motif.as_str() {
+                        "key_compromise" => CrlReason::OcspRevokeKeyCompromise,
+                        "ca_compromise" => CrlReason::OcspRevokeCaCompromise,
+                        "affiliation_changed" => CrlReason::OcspRevokeAffChanged,
+                        "superseded" => CrlReason::OcspRevokeSuperseded,
+                        "cessation_of_operation" => CrlReason::OcspRevokeCessOperation,
+                        "certificate_hold" => CrlReason::OcspRevokeCertHold,
+                        "privilege_withdrawn" => CrlReason::OcspRevokePrivWithdrawn,
+                        "aa_compromise" => CrlReason::OcspRevokeAaCompromise,
+                        _ => CrlReason::OcspRevokeUnspecified,
+                    };
+
+                    Ok(OcspCertStatus::new(
+                        CertStatusCode::Revoked,
+                        Some(RevokedInfo::new(time, Some(motif))),
+                    ))
+                } else {
+                    Ok(OcspCertStatus::new(CertStatusCode::Good, None))
+                }
+            }
+        }).await??;
+
+        Ok(result)
+    }
+
+    fn create_tables_if_needed(&self) -> Result<(), Box<dyn Error + Send + Sync>> {
+        if !self.config.create_table {
+            return Ok(());
+        }
+
+        let mut conn = self.get_connection()?;
+        let query = format!("SHOW TABLES LIKE '{}'", self.table_name);
+
+        // For checking if table exists, we'll use execute instead of load for simpler handling
+        let exists: bool = diesel::sql_query(query)
+            .execute(&mut conn)
+            .map(|count| count > 0)?;
+
+        if exists {
+            info!("Table {} already exists in MySQL database", self.table_name);
+            return Ok(());
+        }
+
+        let create_table_query = format!(
+            "CREATE TABLE `{}` (
+                `cert_num` varchar(50) NOT NULL,
+                `revocation_time` datetime DEFAULT NULL,
+                `revocation_reason` enum('unspecified','key_compromise','ca_compromise','affiliation_changed','superseded','cessation_of_operation','certificate_hold','privilege_withdrawn','aa_compromise') DEFAULT NULL,
+                `status` enum('Valid','Revoked') NOT NULL DEFAULT 'Valid',
+                PRIMARY KEY (`cert_num`)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4",
+            self.table_name
+        );
+
+        diesel::sql_query(create_table_query).execute(&mut conn)?;
+
+        info!(
+            "Table {} created successfully in MySQL database",
+            self.table_name
+        );
+        Ok(())
+    }
+}
+
+pub struct DieselPgDatabase {
+    config: Arc<Config>,
+    pool: PgPool,
+    table_name: String,
+}
+
+impl DieselPgDatabase {
+    pub fn new(config: Arc<Config>) -> Result<Self, Box<dyn Error + Send + Sync>> {
+        let database_url = match &config.dbip {
+            Some(host) => format!(
+                "postgres://{}:{}@{}:{}/{}",
+                config.dbuser,
+                config.dbpassword,
+                host,
+                config.dbport.unwrap_or(DEFAULT_POSTGRES_PORT),
+                config.dbname
+            ),
+            None => format!(
+                "postgres://{}:{}@localhost/{}",
+                config.dbuser, config.dbpassword, config.dbname
+            ),
+        };
+
+        let manager = ConnectionManager::<PgConnection>::new(database_url);
+        let pool = Pool::builder()
+            .max_size(15)
+            .connection_timeout(Duration::from_secs(config.time as u64))
+            .build(manager)?;
+
+        let table_name = config
+            .table_name
+            .clone()
+            .unwrap_or_else(|| DEFAULT_POSTGRES_TABLE.to_string());
+
+        Ok(Self {
+            config,
+            pool,
+            table_name,
+        })
+    }
+
+    fn get_connection(
+        &self,
+    ) -> Result<
+        diesel::r2d2::PooledConnection<ConnectionManager<PgConnection>>,
+        Box<dyn Error + Send + Sync>,
+    > {
+        Ok(self.pool.get()?)
+    }
+}
+
+#[async_trait]
+impl Database for DieselPgDatabase {
+    async fn check_cert(
+        &self,
+        certnum: &str,
+        revoked: bool,
+    ) -> Result<OcspCertStatus, Box<dyn Error + Send + Sync>> {
+        let table_name = self.table_name.clone();
+        let cert_num = certnum.to_string();
+        let connection_manager = self.pool.clone();
+
+        let result = tokio::task::spawn_blocking(move || -> Result<OcspCertStatus, Box<dyn Error + Send + Sync>> {
+            let mut conn = connection_manager.get()?;
+
+            // Using text SQL query with explicit column names and types
+            let query = format!(
+                "SELECT cert_num, revocation_time, revocation_reason, status FROM {} WHERE cert_num = $1",
+                table_name
+            );
+
+            let results = diesel::sql_query(query)
+                .bind::<sql_types::Text, _>(&cert_num)
+                .load::<CertRecord>(&mut conn)?;
+
+            if results.is_empty() {
+                warn!("Entry not found for cert {} in PostgreSQL", cert_num);
+                if !revoked {
+                    Ok(OcspCertStatus::new(CertStatusCode::Unknown, None))
+                } else {
+                    Ok(OcspCertStatus::new(
+                        CertStatusCode::Revoked,
+                        Some(RevokedInfo::new(
+                            GeneralizedTime::new(1970, 1, 1, 0, 0, 0).unwrap(),
+                            Some(CrlReason::OcspRevokeCertHold),
+                        )),
+                    ))
+                }
+            } else {
+                let record = &results[0];
+                debug!("Entry found for cert {}, status {}", cert_num, record.status);
+
+                if record.status == "Revoked" {
+                    let time = GeneralizedTime::now();
+
+                    let time = if let Some(rt) = record.revocation_time {
+                        GeneralizedTime::new(
+                            rt.year(),
+                            rt.month(),
+                            rt.day(),
+                            rt.hour(),
+                            rt.minute(),
+                            rt.second(),
+                        ).unwrap_or(time)
+                    } else {
+                        time
+                    };
+
+                    let motif = record.revocation_reason.clone().unwrap_or_default();
+                    let motif: CrlReason = match motif.as_str() {
+                        "key_compromise" => CrlReason::OcspRevokeKeyCompromise,
+                        "ca_compromise" => CrlReason::OcspRevokeCaCompromise,
+                        "affiliation_changed" => CrlReason::OcspRevokeAffChanged,
+                        "superseded" => CrlReason::OcspRevokeSuperseded,
+                        "cessation_of_operation" => CrlReason::OcspRevokeCessOperation,
+                        "certificate_hold" => CrlReason::OcspRevokeCertHold,
+                        "privilege_withdrawn" => CrlReason::OcspRevokePrivWithdrawn,
+                        "aa_compromise" => CrlReason::OcspRevokeAaCompromise,
+                        _ => CrlReason::OcspRevokeUnspecified,
+                    };
+
+                    Ok(OcspCertStatus::new(
+                        CertStatusCode::Revoked,
+                        Some(RevokedInfo::new(time, Some(motif))),
+                    ))
+                } else {
+                    Ok(OcspCertStatus::new(CertStatusCode::Good, None))
+                }
+            }
+        }).await??;
+
+        Ok(result)
+    }
+
+    fn create_tables_if_needed(&self) -> Result<(), Box<dyn Error + Send + Sync>> {
+        if !self.config.create_table {
+            return Ok(());
+        }
+
+        let mut conn = self.get_connection()?;
+
+        // Using a simpler check query that works well with QueryableByName
+        let exists_query = format!(
+            "SELECT EXISTS (
+                SELECT FROM information_schema.tables
+                WHERE table_schema = 'public'
+                AND table_name = '{}'
+            ) as exists",
+            self.table_name
+        );
+
+        let exists_results = diesel::sql_query(exists_query).load::<BoolResult>(&mut conn)?;
+
+        let exists = !exists_results.is_empty() && exists_results[0].exists;
+
+        if exists {
+            info!(
+                "Table {} already exists in PostgreSQL database",
+                self.table_name
+            );
+            return Ok(());
+        }
+
+        // Check if types exist with a properly formatted query
+        let types_exist_query = "SELECT EXISTS (
+                SELECT FROM pg_type
+                WHERE typname = 'cert_status'
+            ) as exists";
+
+        let types_exist_results =
+            diesel::sql_query(types_exist_query).load::<BoolResult>(&mut conn)?;
+
+        let types_exist = !types_exist_results.is_empty() && types_exist_results[0].exists;
+
+        if !types_exist {
+            // Split into two separate queries to avoid issues
+            diesel::sql_query("CREATE TYPE cert_status AS ENUM ('Valid', 'Revoked');")
+                .execute(&mut conn)?;
+
+            diesel::sql_query(
+                "CREATE TYPE revocation_reason_enum AS ENUM (
+                    'unspecified',
+                    'key_compromise',
+                    'ca_compromise',
+                    'affiliation_changed',
+                    'superseded',
+                    'cessation_of_operation',
+                    'certificate_hold',
+                    'privilege_withdrawn',
+                    'aa_compromise'
+                );",
+            )
+            .execute(&mut conn)?;
+        }
+
+        diesel::sql_query(format!(
+            "CREATE TABLE {} (
+                cert_num VARCHAR(50) PRIMARY KEY,
+                revocation_time TIMESTAMP DEFAULT NULL,
+                revocation_reason revocation_reason_enum DEFAULT NULL,
+                status cert_status NOT NULL DEFAULT 'Valid'
+            );",
+            self.table_name
+        ))
+        .execute(&mut conn)?;
+
+        info!(
+            "Table {} created successfully in PostgreSQL database",
+            self.table_name
+        );
+        Ok(())
+    }
+}
+
+pub fn create_database(
+    config: Arc<Config>,
+) -> Result<Box<dyn Database>, Box<dyn Error + Send + Sync>> {
+    match DatabaseType::from_string(&config.db_type) {
+        DatabaseType::MySQL => {
+            let db = DieselMysqlDatabase::new(config)?;
+            Ok(Box::new(db))
+        }
+        DatabaseType::PostgreSQL => {
+            let db = DieselPgDatabase::new(config)?;
+            Ok(Box::new(db))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mockall::predicate::*;
+    use mockall::*;
+
+    mock! {
+        pub Database {}
+
+        #[async_trait]
+        impl Database for Database {
+            async fn check_cert(
+                &self,
+                certnum: &str,
+                revoked: bool,
+            ) -> Result<OcspCertStatus, Box<dyn Error + Send + Sync>>;
+
+            fn create_tables_if_needed(&self) -> Result<(), Box<dyn Error + Send + Sync>>;
+        }
+    }
+
+    #[test]
+    fn test_database_type_from_string() {
+        assert!(matches!(
+            DatabaseType::from_string("mysql"),
+            DatabaseType::MySQL
+        ));
+        assert!(matches!(
+            DatabaseType::from_string("MySQL"),
+            DatabaseType::MySQL
+        ));
+        assert!(matches!(
+            DatabaseType::from_string("postgresql"),
+            DatabaseType::PostgreSQL
+        ));
+        assert!(matches!(
+            DatabaseType::from_string("postgres"),
+            DatabaseType::PostgreSQL
+        ));
+        assert!(matches!(
+            DatabaseType::from_string("PostgreSQL"),
+            DatabaseType::PostgreSQL
+        ));
+        assert!(matches!(
+            DatabaseType::from_string("unknown"),
+            DatabaseType::MySQL
+        ));
+    }
+
+    #[test]
+    fn test_default_table_names() {
+        assert_eq!(
+            DatabaseType::MySQL.default_table_name(),
+            DEFAULT_MYSQL_TABLE
+        );
+        assert_eq!(
+            DatabaseType::PostgreSQL.default_table_name(),
+            DEFAULT_POSTGRES_TABLE
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,10 @@
-#[macro_use]
 extern crate rocket;
+
 use chrono::{self, NaiveDateTime, Timelike};
 use chrono::{DateTime, Datelike, FixedOffset};
 use clap::Parser;
 use config_file::FromConfigFile;
-use mysql::prelude::Queryable;
-use mysql::*;
+use log::{debug, error, info, trace, warn};
 use ocsp::common::asn1::Bytes;
 use ocsp::common::ocsp::{OcspExt, OcspExtI};
 use ocsp::request::OcspRequest;
@@ -14,11 +13,12 @@ use ocsp::{
     err::OcspError,
     oid::{ALGO_SHA256_WITH_RSA_ENCRYPTION_DOT, OCSP_RESPONSE_BASIC_DOT},
     response::{
-        BasicResponse, CertStatus as OcspCertStatus, CertStatus, CertStatusCode, CrlReason,
-        OcspRespStatus, OcspResponse, OneResp, ResponderId, ResponseBytes, ResponseData,
-        RevokedInfo,
+        BasicResponse, CertStatus, CertStatusCode, OcspRespStatus, OcspResponse, OneResp,
+        ResponderId, ResponseBytes, ResponseData,
     },
 };
+use openssl::pkey::PKey;
+use openssl::rsa::Rsa;
 use pem::parse;
 use r#struct::*;
 use ring::digest::SHA1_FOR_LEGACY_USE_ONLY;
@@ -26,19 +26,25 @@ use ring::{rand, signature};
 use rocket::http::ContentType;
 use rocket::State;
 use rocket::{data::ToByteUnit, Data};
+use rocket::{get, launch, post, routes};
 use std::error::Error;
 use std::fs;
 use std::io;
 use std::net::SocketAddr;
 use std::path::Path;
-use std::time::Duration;
+use std::sync::Arc;
 use x509_parser::oid_registry::OID_X509_EXT_AUTHORITY_KEY_IDENTIFIER;
 use x509_parser::prelude::ParsedExtension;
 use zeroize::Zeroize;
+
+mod database;
 mod r#struct;
+
+use database::Database;
+
 fn signresponse(
     issuer_hash: &[u8],
-    private_key: &ring::rsa::KeyPair,
+    private_key: &ring::signature::RsaKeyPair,
     response: Vec<OneResp>,
     extensions: Option<Vec<OcspExtI>>,
     cert: Option<Vec<Bytes>>,
@@ -61,95 +67,17 @@ fn signresponse(
     let bytes = ResponseBytes::new_basic(resp_type, basic)?;
     Ok(bytes)
 }
+
 fn signvalidresponse(bytes: ResponseBytes) -> Result<Vec<u8>, OcspError> {
     let ocsp = OcspResponse::new_success(bytes);
     ocsp.to_der()
 }
+
 fn signnonvalidresponse(motif: OcspRespStatus) -> Result<Vec<u8>, OcspError> {
     let ocsp = OcspResponse::new_non_success(motif)?;
     ocsp.to_der()
 }
-fn checkcert(
-    config: &State<Config>,
-    certnum: &str,
-    revoked: bool,
-) -> Result<OcspCertStatus, mysql::Error> {
-    // Let's select payments from database. Type inference should do the trick here.
-    let opts = OptsBuilder::new()
-        .user(Some(config.dbuser.as_str()))
-        .read_timeout(Some(Duration::new(config.time as u64, 0)))
-        .db_name(Some(config.dbname.as_str()))
-        .pass(Some(config.dbpassword.as_str()));
-    let opts = match &config.dbip {
-        Some(string) => opts.ip_or_hostname(Some(string)),
-        None => opts
-            .prefer_socket(true)
-            .socket(Some("/run/mysqld/mysqld.sock")),
-    };
-    let mut conn = Conn::new(opts)?;
-    let status = conn.exec_map(
-        "SELECT status, revocation_time, revocation_reason FROM list_certs WHERE cert_num=?",
-        (String::from(certnum).into_bytes(),),
-        |(status, revocation_time, revocation_reason)| Certinfo {
-            status,
-            revocation_time,
-            revocation_reason,
-        },
-    )?;
-    if status.is_empty() {
-        warn!("Entry not found for cert {}", certnum);
-        if !revoked {
-            Ok(OcspCertStatus::new(CertStatusCode::Unknown, None))
-        } else {
-            Ok(OcspCertStatus::new(
-                CertStatusCode::Revoked,
-                Some(RevokedInfo::new(
-                    GeneralizedTime::new(1970, 1, 1, 0, 0, 0).unwrap(),
-                    Some(CrlReason::OcspRevokeCertHold),
-                )),
-            ))
-        }
-    } else {
-        let statut = status[0].clone();
-        debug!("Entry found for cert {}, status {}", certnum, statut.status);
-        if statut.status == "Revoked" {
-            let time = GeneralizedTime::now();
-            let date = &statut.revocation_time;
-            let timenew = match date {
-                Some(mysql::Value::Date(year, month, day, hour, min, sec, _ms)) => {
-                    GeneralizedTime::new(
-                        i32::from(*year),
-                        u32::from(*month),
-                        u32::from(*day),
-                        u32::from(*hour),
-                        u32::from(*min),
-                        u32::from(*sec),
-                    )
-                }
-                _ => Ok(time),
-            };
-            let time = timenew.unwrap_or(time);
-            let motif = statut.revocation_reason.unwrap_or_default();
-            let motif: CrlReason = match motif.as_str() {
-                "key_compromise" => CrlReason::OcspRevokeKeyCompromise,
-                "ca_compromise" => CrlReason::OcspRevokeCaCompromise,
-                "affiliation_changed" => CrlReason::OcspRevokeAffChanged,
-                "superseded" => CrlReason::OcspRevokeSuperseded,
-                "cessation_of_operation" => CrlReason::OcspRevokeCessOperation,
-                "certificate_hold" => CrlReason::OcspRevokeCertHold,
-                "privilege_withdrawn" => CrlReason::OcspRevokePrivWithdrawn,
-                "aa_compromise" => CrlReason::OcspRevokeAaCompromise,
-                _ => CrlReason::OcspRevokeUnspecified,
-            };
-            Ok(OcspCertStatus::new(
-                CertStatusCode::Revoked,
-                Some(RevokedInfo::new(time, Some(motif))),
-            ))
-        } else {
-            Ok(OcspCertStatus::new(CertStatusCode::Good, None))
-        }
-    }
-}
+
 fn createocspresponse(
     cert: CertId,
     cert_status: CertStatus,
@@ -183,7 +111,8 @@ fn createocspresponse(
         one_resp_ext: extension,
     })
 }
-fn checkcache(state: &State<Config>, certname: &str) -> io::Result<Option<Vec<u8>>> {
+
+fn checkcache(state: &State<Arc<Config>>, certname: &str) -> io::Result<Option<Vec<u8>>> {
     let paths = fs::read_dir(&state.cachefolder)?;
     for path in paths {
         let path = path?.path();
@@ -193,7 +122,7 @@ fn checkcache(state: &State<Config>, certname: &str) -> io::Result<Option<Vec<u8
             .to_str()
             .unwrap_or_default();
         if filename.starts_with(certname) {
-            let elem: Vec<&str> = filename.split(&certname).collect();
+            let elem: Vec<&str> = filename.split(certname).collect();
             if elem.len() != 2 {
                 warn!("Invalid filename to check cache: {}", filename);
                 continue;
@@ -226,8 +155,9 @@ fn checkcache(state: &State<Config>, certname: &str) -> io::Result<Option<Vec<u8
     }
     Ok(None)
 }
+
 fn addtocache(
-    state: &State<Config>,
+    state: &State<Arc<Config>>,
     certnum: &str,
     maxdate: DateTime<FixedOffset>,
     response: &[u8],
@@ -241,17 +171,21 @@ fn addtocache(
     let path = Path::new(&long);
     fs::write(path, response)
 }
+
 #[post("/<_..>", data = "<data>")]
 async fn upload2(
-    config: &State<Config>,
+    config: &State<Arc<Config>>,
+    db: &State<Box<dyn Database>>,
     data: Data<'_>,
     address: SocketAddr,
 ) -> io::Result<(ContentType, Vec<u8>)> {
-    upload(config, data, address).await
+    upload(config, db, data, address).await
 }
+
 #[get("/<_..>", data = "<data>")]
 async fn upload(
-    state: &State<Config>,
+    state: &State<Arc<Config>>,
+    db: &State<Box<dyn Database>>,
     data: Data<'_>,
     address: SocketAddr,
 ) -> io::Result<(ContentType, Vec<u8>)> {
@@ -352,7 +286,8 @@ async fn upload(
             };
             extensions.push(revoked);
         };
-        //Compare that signing certificate is signed by the issuer or the issuer itself https://www.rfc-editor.org/rfc/rfc6960
+
+        // Compare that signing certificate is signed by the issuer or the issuer itself https://www.rfc-editor.org/rfc/rfc6960
         let status = match (
             cert.issuer_key_hash == state.issuer_hash.0,
             state.issuer_hash.1 == cert.issuer_key_hash,
@@ -365,10 +300,11 @@ async fn upload(
                 } else {
                     trace!("Certificate is the issuer.");
                 }
-                match checkcert(state, &num, state.revocextended) {
+
+                match db.check_cert(&num, state.revocextended).await {
                     Ok(status) => status,
-                    Err(default) => {
-                        error!("Cannot connect to database: {}", default.to_string());
+                    Err(err) => {
+                        error!("Cannot query database: {}", err);
                         return Ok((
                             custom,
                             signnonvalidresponse(OcspRespStatus::TryLater).unwrap(),
@@ -396,11 +332,7 @@ async fn upload(
                 CertStatus::new(CertStatusCode::Unknown, None)
             }
         };
-        /* let mut extension = OcspExtI {
-            id: i2b_oid(ocsp::common::asn1::Oid::new_from_dot(OCSP_EXT_EXTENDED_REVOKE_DOT)),
-            ext: ocsp::common::ocsp::OcspExt::CrlRef { url: None, num: Some(OCSP_EXT_EXTENDED_REVOKE_HEX.to_vec()), time: None }
-        };
-        let resp = createocspresponse(cert, status, Some(state.cachedays), None, None, Some(vec![extension])); */
+
         let resp = createocspresponse(cert, status, Some(state.cachedays), None, None, None);
         if resp.is_err() {
             error!("Error creating OCSP response.");
@@ -456,9 +388,9 @@ async fn upload(
     let response = response.unwrap();
     if possible {
         let date = chrono::Local::now();
-        let date = date.checked_add_days(chrono::Days::new(state.cachedays.into())); //TODO: Implement
-        if date.is_some() {
-            match addtocache(state, &certnum, date.unwrap().fixed_offset(), &response) {
+        let date = date.checked_add_days(chrono::Days::new(u64::from(state.cachedays)));
+        if let Some(date) = date {
+            match addtocache(state, &certnum, date.fixed_offset(), &response) {
                 Ok(_) => (),
                 Err(_) => {
                     warn!("Cannot write to cache");
@@ -469,11 +401,52 @@ async fn upload(
     info!("Send response for {} to {}", &certnum, address.ip());
     Ok((custom, response))
 }
-fn getprivatekey<T>(data: T) -> Result<ring::rsa::KeyPair, ring::error::KeyRejected>
+
+fn getprivatekey<T>(data: T) -> Result<ring::signature::RsaKeyPair, String>
 where
     T: AsRef<[u8]>,
 {
-    ring::rsa::KeyPair::from_pkcs8(data.as_ref())
+    if let Ok(key_pair) = ring::signature::RsaKeyPair::from_pkcs8(data.as_ref()) {
+        return Ok(key_pair);
+    }
+
+    let pem_str = String::from_utf8_lossy(data.as_ref());
+
+    if pem_str.contains("-----BEGIN RSA PRIVATE KEY-----") {
+        match convert_rsa_pem_to_pkcs8(&pem_str) {
+            Ok(pkcs8_der) => match ring::signature::RsaKeyPair::from_pkcs8(&pkcs8_der) {
+                Ok(key_pair) => return Ok(key_pair),
+                Err(e) => {
+                    return Err(format!(
+                        "Error creating KeyPair from converted PKCS#8: {}",
+                        e
+                    ))
+                }
+            },
+            Err(e) => return Err(format!("RSA PEM conversion error: {}", e)),
+        }
+    } else if pem_str.contains("-----BEGIN PRIVATE KEY-----") {
+        match pem::parse(pem_str.as_bytes()) {
+            Ok(pem) => match ring::signature::RsaKeyPair::from_pkcs8(pem.contents()) {
+                Ok(key_pair) => return Ok(key_pair),
+                Err(e) => return Err(format!("Error creating KeyPair from PEM PKCS#8: {}", e)),
+            },
+            Err(e) => return Err(format!("PEM parsing error: {}", e)),
+        }
+    } else if pem_str.contains("-----BEGIN EC PRIVATE KEY-----") {
+        return Err("EC key format is not supported".to_string());
+    }
+
+    Err("Unsupported key format".to_string())
+}
+
+fn convert_rsa_pem_to_pkcs8(
+    pem_str: &str,
+) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>> {
+    let pem = pem::parse(pem_str.as_bytes())?;
+    let rsa = Rsa::private_key_from_der(pem.contents())?;
+    let pkey = PKey::from_rsa(rsa)?;
+    Ok(pkey.private_key_to_pkcs8()?)
 }
 
 fn pem_to_der(pem_str: &str) -> Vec<u8> {
@@ -485,8 +458,9 @@ fn pem_to_der(pem_str: &str) -> Vec<u8> {
         }
     }
 }
+
 #[launch]
-fn rocket() -> _ {
+fn rocket() -> rocket::Rocket<rocket::Build> {
     let cli = Cli::parse();
 
     let config_path = &cli.config_path;
@@ -519,7 +493,7 @@ fn rocket() -> _ {
             "Your certificate does not have OCSP signing extended key usage. If it is not the issuer, the application won't sign the response."
         )
     }
-    //let subjectkey = format!("{:x}", issuerkey).to_uppercase().replace(":", "");
+
     let parsed = certpem
         .get_extension_unique(&OID_X509_EXT_AUTHORITY_KEY_IDENTIFIER)
         .unwrap()
@@ -531,26 +505,50 @@ fn rocket() -> _ {
             panic!("Error getting key");
         }
     };
-    //For an unknown reason, subject key identifier is not equal to SHA1 hash key so it is used instead.
+
+    // For an unknown reason, subject key identifier is not equal to SHA1 hash key so it is used instead.
     let authoritykey = format!("{:x}", issuerkey).to_uppercase().replace(":", "");
     let certpempublickey = &certpem.public_key().subject_public_key.data;
     let sha1key = ring::digest::digest(&SHA1_FOR_LEGACY_USE_ONLY, certpempublickey);
-    //let issuer_name_hash = certpem.subject_name_hash();
-    let mut key = fs::read(&config.itkey).unwrap();
-    let rsakey = getprivatekey(&key).unwrap();
+
+    // Read private key and zero it after use
+    let mut key = fs::read(&config.itkey).unwrap_or_else(|e| {
+        panic!("Error reading key file: {}", e);
+    });
+
+    let rsakey = match getprivatekey(&key) {
+        Ok(key_pair) => key_pair,
+        Err(e) => {
+            eprintln!("Error loading private key: {}", e);
+            eprintln!("Supported formats: PKCS#8, PEM PKCS#1 (RSA)");
+            panic!("Key loading failed");
+        }
+    };
     key.zeroize();
+
+    // Get HTTP port
     let port = config.port.unwrap_or(DEFAULT_PORT);
-    let config = Config {
+
+    // Determine database type and default port
+    let db_type = config
+        .db_type
+        .clone()
+        .unwrap_or_else(|| "mysql".to_string());
+    let dbport = match db_type.as_str() {
+        "postgres" | "postgresql" => config.dbport.or(Some(DEFAULT_POSTGRES_PORT)),
+        _ => config.dbport.or(Some(DEFAULT_MYSQL_PORT)),
+    };
+
+    // Create configuration
+    let config = Arc::new(Config {
         issuer_hash: (
             sha1key.as_ref().to_vec(),
-            //hex::decode(subjectkey).unwrap(),
             hex::decode(authoritykey).unwrap(),
             isocsp,
         ),
         revocextended: config.revocextended.unwrap_or(false),
         cert: file2,
         time: config.timeout.unwrap_or(DEFAULT_TIMEOUT),
-        //issuer_name_hash,
         rsakey,
         cachefolder: config.cachefolder.clone(),
         caching: config.caching.unwrap_or(true),
@@ -559,94 +557,35 @@ fn rocket() -> _ {
         dbuser: config.dbuser.clone(),
         dbpassword: config.dbpassword.clone(),
         dbname: config.dbname.clone(),
+        db_type,
+        dbport,
+        create_table: config.create_table.unwrap_or(false),
+        table_name: config.table_name.clone(),
+    });
+
+    // Create database connection and tables if needed
+    let db = match database::create_database(config.clone()) {
+        Ok(db) => {
+            if let Err(e) = db.create_tables_if_needed() {
+                eprintln!("Error creating tables: {}", e);
+            }
+            db
+        }
+        Err(e) => {
+            panic!("Failed to initialize database: {}", e);
+        }
     };
+
+    // Create cache folder if it doesn't exist
     let path = Path::new(config.cachefolder.as_str());
     if !path.exists() {
         fs::create_dir_all(path).expect("Cannot create cache folder");
     }
+
     rocket::build()
         .configure(rocket::Config::figment().merge(("port", port)))
         .mount("/", routes![upload])
         .mount("/", routes![upload2])
         .manage(config)
-}
-#[cfg(test)]
-mod tests {
-    use crate::rocket;
-    use crate::Cli;
-    use crate::{getprivatekey, Fileconfig};
-    use clap::Parser;
-    use config_file::FromConfigFile;
-    use ring::rand::SecureRandom;
-    use ring::signature::KeyPair;
-    use ring::{rand, signature};
-    use std::path::Path;
-    use std::{fs, time::Instant};
-    use zeroize::Zeroize;
-    #[test]
-    fn testresponse() {
-        println!("Generating key, may take a while...");
-        let rng = rand::SystemRandom::new();
-        let pkcs8_bytes = signature::Ed25519KeyPair::generate_pkcs8(&rng).unwrap();
-
-        // Normally the application would store the PKCS#8 file persistently. Later
-        // it would read the PKCS#8 file from persistent storage to use it.
-
-        let key_pair = signature::Ed25519KeyPair::from_pkcs8(pkcs8_bytes.as_ref()).unwrap();
-
-        println!("Done.");
-        let mut tosign = [0u8; 3000];
-        println!("Generating random");
-        rng.fill(&mut tosign).unwrap();
-        println!("Done!");
-        let time = Instant::now();
-        for i in 0..100 {
-            if i % 10 == 0 {
-                rng.fill(&mut tosign).unwrap();
-            }
-            let sig = key_pair.sign(&tosign);
-            // Normally an application would extract the bytes of the signature and
-            // send them in a protocol message to the peer(s). Here we just get the
-            // public key key directly from the key pair.
-            let peer_public_key_bytes = key_pair.public_key().as_ref();
-
-            // Verify the signature of the message using the public key. Normally the
-            // verifier of the message would parse the inputs to this code out of the
-            // protocol message(s) sent by the signer.
-            let peer_public_key =
-                signature::UnparsedPublicKey::new(&signature::ED25519, peer_public_key_bytes);
-            peer_public_key.verify(&tosign, sig.as_ref()).unwrap();
-        }
-        println!("Elapsed time : {:.6} ms", time.elapsed().as_millis());
-    }
-    #[test]
-    #[should_panic(
-        expected = "called `Result::unwrap()` on an `Err` value: KeyRejected(\"InvalidEncoding\")"
-    )]
-    fn checkconfigfake() {
-        let cli = Cli::parse();
-
-        let config_path = &cli.config_path;
-
-        if !Path::new(config_path).exists() {
-            panic!("Config file not found at: {}", config_path);
-        }
-
-        let mut config = match Fileconfig::from_config_file(config_path) {
-            Ok(config) => config,
-            Err(e) => {
-                panic!("Error reading config file at {}: {}", config_path, e);
-            }
-        };
-        config.itkey = String::from("test_files/key.pem");
-        //For an unknown reason, subject key identifier is not equal to SHA1 hash key so it is used instead.
-        //let issuer_name_hash = certpem.subject_name_hash();
-        let mut key = fs::read(&config.itkey).unwrap();
-        let _rsakey = getprivatekey(&key).unwrap();
-        key.zeroize();
-    }
-    #[test]
-    fn checkconfig() {
-        rocket();
-    }
+        .manage(db as Box<dyn Database>)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,12 +20,12 @@ use ocsp::{
     },
 };
 use pem::parse;
+use r#struct::*;
 use ring::digest::SHA1_FOR_LEGACY_USE_ONLY;
 use ring::{rand, signature};
-use rocket::State;
 use rocket::http::ContentType;
-use rocket::{Data, data::ToByteUnit};
-use r#struct::*;
+use rocket::State;
+use rocket::{data::ToByteUnit, Data};
 use std::error::Error;
 use std::fs;
 use std::io;
@@ -572,81 +572,81 @@ fn rocket() -> _ {
 }
 #[cfg(test)]
 mod tests {
+    use crate::rocket;
+    use crate::Cli;
+    use crate::{getprivatekey, Fileconfig};
+    use clap::Parser;
+    use config_file::FromConfigFile;
     use ring::rand::SecureRandom;
     use ring::signature::KeyPair;
-    use zeroize::Zeroize;
-    use std::{fs, time::Instant};
-        use std::path::Path;
-        use crate::rocket;
-    use clap::Parser;
-    use crate::{getprivatekey, Fileconfig};
     use ring::{rand, signature};
-    use config_file::FromConfigFile;
-    use crate::Cli;
-#[test]
-fn testresponse() {
-    println!("Generating key, may take a while...");
-    let rng = rand::SystemRandom::new();
-    let pkcs8_bytes = signature::Ed25519KeyPair::generate_pkcs8(&rng).unwrap();
+    use std::path::Path;
+    use std::{fs, time::Instant};
+    use zeroize::Zeroize;
+    #[test]
+    fn testresponse() {
+        println!("Generating key, may take a while...");
+        let rng = rand::SystemRandom::new();
+        let pkcs8_bytes = signature::Ed25519KeyPair::generate_pkcs8(&rng).unwrap();
 
-    // Normally the application would store the PKCS#8 file persistently. Later
-    // it would read the PKCS#8 file from persistent storage to use it.
+        // Normally the application would store the PKCS#8 file persistently. Later
+        // it would read the PKCS#8 file from persistent storage to use it.
 
-    let key_pair = signature::Ed25519KeyPair::from_pkcs8(pkcs8_bytes.as_ref()).unwrap();
+        let key_pair = signature::Ed25519KeyPair::from_pkcs8(pkcs8_bytes.as_ref()).unwrap();
 
-    println!("Done.");
-    let mut tosign = [0u8; 3000];
-    println!("Generating random");
-    rng.fill(&mut tosign).unwrap();
-    println!("Done!");
-    let time = Instant::now();
-    for i in 0..100 {
-        if i % 10 == 0 {
-            rng.fill(&mut tosign).unwrap();
+        println!("Done.");
+        let mut tosign = [0u8; 3000];
+        println!("Generating random");
+        rng.fill(&mut tosign).unwrap();
+        println!("Done!");
+        let time = Instant::now();
+        for i in 0..100 {
+            if i % 10 == 0 {
+                rng.fill(&mut tosign).unwrap();
+            }
+            let sig = key_pair.sign(&tosign);
+            // Normally an application would extract the bytes of the signature and
+            // send them in a protocol message to the peer(s). Here we just get the
+            // public key key directly from the key pair.
+            let peer_public_key_bytes = key_pair.public_key().as_ref();
+
+            // Verify the signature of the message using the public key. Normally the
+            // verifier of the message would parse the inputs to this code out of the
+            // protocol message(s) sent by the signer.
+            let peer_public_key =
+                signature::UnparsedPublicKey::new(&signature::ED25519, peer_public_key_bytes);
+            peer_public_key.verify(&tosign, sig.as_ref()).unwrap();
         }
-        let sig = key_pair.sign(&tosign);
-        // Normally an application would extract the bytes of the signature and
-        // send them in a protocol message to the peer(s). Here we just get the
-        // public key key directly from the key pair.
-        let peer_public_key_bytes = key_pair.public_key().as_ref();
-
-        // Verify the signature of the message using the public key. Normally the
-        // verifier of the message would parse the inputs to this code out of the
-        // protocol message(s) sent by the signer.
-        let peer_public_key =
-            signature::UnparsedPublicKey::new(&signature::ED25519, peer_public_key_bytes);
-        peer_public_key.verify(&tosign, sig.as_ref()).unwrap();
+        println!("Elapsed time : {:.6} ms", time.elapsed().as_millis());
     }
-    println!("Elapsed time : {:.6} ms", time.elapsed().as_millis());
-}
-#[test]
-#[should_panic(
-    expected = "called `Result::unwrap()` on an `Err` value: KeyRejected(\"InvalidEncoding\")"
-)]
-fn checkconfigfake() {
-    let cli = Cli::parse();
+    #[test]
+    #[should_panic(
+        expected = "called `Result::unwrap()` on an `Err` value: KeyRejected(\"InvalidEncoding\")"
+    )]
+    fn checkconfigfake() {
+        let cli = Cli::parse();
 
-    let config_path = &cli.config_path;
+        let config_path = &cli.config_path;
 
-    if !Path::new(config_path).exists() {
-        panic!("Config file not found at: {}", config_path);
-    }
-
-    let mut config = match Fileconfig::from_config_file(config_path) {
-        Ok(config) => config,
-        Err(e) => {
-            panic!("Error reading config file at {}: {}", config_path, e);
+        if !Path::new(config_path).exists() {
+            panic!("Config file not found at: {}", config_path);
         }
-    };
-    config.itkey = String::from("test_files/key.pem");
-    //For an unknown reason, subject key identifier is not equal to SHA1 hash key so it is used instead.
-    //let issuer_name_hash = certpem.subject_name_hash();
-    let mut key = fs::read(&config.itkey).unwrap();
-    let _rsakey = getprivatekey(&key).unwrap();
-    key.zeroize();
-}
-#[test]
-fn checkconfig() {
-    rocket();
-}
+
+        let mut config = match Fileconfig::from_config_file(config_path) {
+            Ok(config) => config,
+            Err(e) => {
+                panic!("Error reading config file at {}: {}", config_path, e);
+            }
+        };
+        config.itkey = String::from("test_files/key.pem");
+        //For an unknown reason, subject key identifier is not equal to SHA1 hash key so it is used instead.
+        //let issuer_name_hash = certpem.subject_name_hash();
+        let mut key = fs::read(&config.itkey).unwrap();
+        let _rsakey = getprivatekey(&key).unwrap();
+        key.zeroize();
+    }
+    #[test]
+    fn checkconfig() {
+        rocket();
+    }
 }

--- a/src/struct.rs
+++ b/src/struct.rs
@@ -1,7 +1,7 @@
-use clap::{Parser, crate_authors};
+use clap::{crate_authors, Parser};
 use ocsp::common::asn1::Bytes;
-use zeroize::Zeroize;
 use serde::Deserialize;
+use zeroize::Zeroize;
 #[derive(Parser, Debug)]
 #[clap(
     author = crate_authors!("\n"),

--- a/src/struct.rs
+++ b/src/struct.rs
@@ -28,6 +28,7 @@ pub(crate) struct Cli {
 
 pub(crate) const CACHEFORMAT: &str = "%Y-%m-%d-%H-%M-%S";
 pub(crate) const DEFAULT_PORT: u16 = 9000;
+pub(crate) const DEFAULT_LISTEN_IP: &str = "127.0.0.1";
 pub(crate) const DEFAULT_TIMEOUT: u8 = 5;
 pub(crate) const DEFAULT_MYSQL_PORT: u16 = 3306;
 pub(crate) const DEFAULT_POSTGRES_PORT: u16 = 5432;
@@ -55,6 +56,7 @@ pub(crate) struct Config {
     pub(crate) table_name: Option<String>,
     pub(crate) api_keys: Option<Vec<String>>,
     pub(crate) enable_api: bool,
+    pub(crate) listen_ip: String,
 }
 
 // Don't implement Default for Config, because we can't easily create a dummy RsaKeyPair.
@@ -76,6 +78,7 @@ pub(crate) struct Fileconfig {
     pub(crate) revocextended: Option<bool>,
     pub(crate) dbip: Option<String>,
     pub(crate) port: Option<u16>,
+    pub(crate) listen_ip: Option<String>,
     pub(crate) timeout: Option<u8>,
     pub(crate) dbuser: String,
     pub(crate) dbpassword: String,

--- a/src/struct.rs
+++ b/src/struct.rs
@@ -1,7 +1,9 @@
 use clap::{crate_authors, Parser};
+use diesel::QueryableByName;
 use ocsp::common::asn1::Bytes;
 use serde::Deserialize;
 use zeroize::Zeroize;
+
 #[derive(Parser, Debug)]
 #[clap(
     author = crate_authors!("\n"),
@@ -26,14 +28,17 @@ pub(crate) struct Cli {
 pub(crate) const CACHEFORMAT: &str = "%Y-%m-%d-%H-%M-%S";
 pub(crate) const DEFAULT_PORT: u16 = 9000;
 pub(crate) const DEFAULT_TIMEOUT: u8 = 5;
-// In a real application, this would likely be more complex.
+pub(crate) const DEFAULT_MYSQL_PORT: u16 = 3306;
+pub(crate) const DEFAULT_POSTGRES_PORT: u16 = 5432;
+pub(crate) const DEFAULT_MYSQL_TABLE: &str = "list_certs";
+pub(crate) const DEFAULT_POSTGRES_TABLE: &str = "ocsp_list_certs";
+
 #[derive(Debug)]
 pub(crate) struct Config {
     pub(crate) issuer_hash: (Vec<u8>, Vec<u8>, bool),
     pub(crate) cert: Bytes,
     pub(crate) revocextended: bool,
     pub(crate) time: u8,
-    //issuer_name_hash: u32,
     pub(crate) rsakey: ring::signature::RsaKeyPair,
     pub(crate) cachedays: u16,
     pub(crate) caching: bool,
@@ -41,8 +46,16 @@ pub(crate) struct Config {
     pub(crate) dbuser: String,
     pub(crate) dbpassword: String,
     pub(crate) dbname: String,
+    pub(crate) db_type: String,
+    pub(crate) dbport: Option<u16>,
+    pub(crate) create_table: bool,
     pub(crate) cachefolder: String,
+    pub(crate) table_name: Option<String>,
 }
+
+// Don't implement Default for Config, because we can't easily create a dummy RsaKeyPair.
+// We'll use explicit constructors in tests instead.
+
 impl Drop for Config {
     fn drop(&mut self) {
         self.dbip.zeroize();
@@ -51,6 +64,7 @@ impl Drop for Config {
         self.dbname.zeroize();
     }
 }
+
 #[derive(Deserialize)]
 pub(crate) struct Fileconfig {
     pub(crate) cachedays: u16,
@@ -62,21 +76,50 @@ pub(crate) struct Fileconfig {
     pub(crate) dbuser: String,
     pub(crate) dbpassword: String,
     pub(crate) dbname: String,
+    pub(crate) db_type: Option<String>,
+    pub(crate) dbport: Option<u16>,
+    pub(crate) create_table: Option<bool>,
     pub(crate) cachefolder: String,
     pub(crate) itkey: String,
     pub(crate) itcert: String,
+    pub(crate) table_name: Option<String>,
 }
+
 impl Drop for Fileconfig {
     fn drop(&mut self) {
         self.dbip.zeroize();
         self.dbuser.zeroize();
         self.dbpassword.zeroize();
         self.dbname.zeroize();
+        self.itkey.zeroize();
     }
 }
+
 #[derive(Debug, PartialEq, Clone)]
+#[allow(dead_code)]
 pub(crate) struct Certinfo {
     pub(crate) status: String,
-    pub(crate) revocation_time: Option<mysql::Value>,
+    pub(crate) revocation_time: Option<chrono::NaiveDateTime>,
     pub(crate) revocation_reason: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, QueryableByName)]
+pub(crate) struct CertRecord {
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    pub(crate) cert_num: String,
+
+    #[diesel(sql_type = diesel::sql_types::Nullable<diesel::sql_types::Timestamp>)]
+    pub(crate) revocation_time: Option<chrono::NaiveDateTime>,
+
+    #[diesel(sql_type = diesel::sql_types::Nullable<diesel::sql_types::Text>)]
+    pub(crate) revocation_reason: Option<String>,
+
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    pub(crate) status: String,
+}
+
+#[derive(Debug, QueryableByName)]
+pub(crate) struct BoolResult {
+    #[diesel(sql_type = diesel::sql_types::Bool)]
+    pub(crate) exists: bool,
 }

--- a/src/struct.rs
+++ b/src/struct.rs
@@ -33,6 +33,7 @@ pub(crate) const DEFAULT_MYSQL_PORT: u16 = 3306;
 pub(crate) const DEFAULT_POSTGRES_PORT: u16 = 5432;
 pub(crate) const DEFAULT_MYSQL_TABLE: &str = "list_certs";
 pub(crate) const DEFAULT_POSTGRES_TABLE: &str = "ocsp_list_certs";
+pub(crate) const DEFAULT_SQLITE_TABLE: &str = "ocsp_list_certs";
 
 #[derive(Debug)]
 pub(crate) struct Config {


### PR DESCRIPTION
Fix Issue : https://github.com/DorianCoding/OCSP-server/issues/15 https://github.com/DorianCoding/OCSP-server/issues/17

- Add PostgreSQL Support
- Refactor DB
- Initialize DB (MySQL or PSQL)
- Create more explicit table `list_certs` to `ocsp_list_certs` (Prevent Conflict)
- Add possibility to set table (Keep Compatibility for older users)
- Add Full API Rest Support
- Improve MySQL & PSQL Support with Diesel.
- Some fix & improvement.
- Add new tests
- App Packaged
- App Module done (For Automation Part)
- New DB Refactor to Enum
- Add SQLite Support
- Add Custom IP Support

Next Features  is coming quickly.

Tested for production use.

Please can you make new release 0.4.2 for me :D

Best Regards